### PR TITLE
Fix: Remove hardcoded API key and add user input prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Simply take a photo of your trash with your smartphone, and the AI will identify
 
 ---
 
+## 🔑 API Key Setup
+
+### Get Your Free Google Gemini API Key
+
+1. Visit: https://makersuite.google.com/app/apikey
+2. Sign in with your Google account
+3. Click "Create API Key"
+4. Copy your API key
+
+### First Launch
+
+- Open `index.html` in your browser
+- You'll be prompted to enter your API key
+- The key will be securely saved in your browser's localStorage
+
+**Note**: Your API key is stored locally in your browser and is never shared. To reset your API key, clear your browser's localStorage or enter a new one when prompted.
+
+---
+
 ## 💻 Languages
 
 - HTML5  

--- a/index.html
+++ b/index.html
@@ -311,8 +311,24 @@
             suggestionsContainer.classList.remove('hidden');
         }
         
+        function getApiKey() {
+            let apiKey = localStorage.getItem('geminiApiKey');
+            if (!apiKey || apiKey === 'YOUR_API_KEY_HERE') {
+                apiKey = prompt('Google Gemini API キーを入力してください:\n\n無料で取得できます: https://makersuite.google.com/app/apikey\n\n※このキーはブラウザのlocalStorageに保存されます。');
+                if (apiKey) {
+                    localStorage.setItem('geminiApiKey', apiKey);
+                } else {
+                    return null;
+                }
+            }
+            return apiKey;
+        }
+        
         async function analyzeImageWithRetry(base64ImageData, maxRetries = 3) {
-            const apiKey = "AIzaSyDaTH9oxiD5PayXdcwKBRJE1UZphXK53cw";
+            const apiKey = getApiKey();
+            if (!apiKey) {
+                return { error: 'API キーが設定されていません。ページをリロードして再度入力してください。' };
+            }
             const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
             const prompt = `この画像に写っている主要な物体を1つ特定し、それが日本の一般的なゴミ分別においてどのカテゴリに分類されるか判断してください。カテゴリは必ず以下のリストから選択してください: 「燃えるゴミ」「燃えないゴミ」「びん」「かん」「ペットボトル」「プラスチック」「紙類」「有害ごみ」「粗大ごみ」。以下のJSON形式で、キーは英語、値は日本語で厳密に回答してください。JSON以外のテキストは含めないでください。
             { "itemName": "物体の名前", "category": "カテゴリ名", "note": "分別する際の一般的な注意点" }`;


### PR DESCRIPTION
## Description

This PR fixes the security vulnerability where the Google Gemini API key was hardcoded in the client-side code.

## Changes

- Removed exposed Google Gemini API key from `index.html`
- Added `getApiKey()` function that prompts users to enter their own API key
- API key is securely stored in browser's localStorage
- Updated `README.md` with clear instructions on how to obtain a free API key from Google
- Added error handling for cases where API key is not provided

## How it works

1. On first use, users are prompted to enter their Google Gemini API key
2. The key is saved in localStorage for future use
3. Users can reset their key by clearing localStorage or entering a new one when prompted

## Security Benefits

- No more exposed API keys in public repository
- Each user uses their own API key (no cost/quota sharing)
- Users have full control over their API key
- Follows Google Cloud API best practices

## Testing

- Tested prompt functionality
- Verified localStorage persistence
- Confirmed error handling works correctly
- Updated documentation is clear and accurate

Fixes #2

🎃 This PR is part of Hacktoberfest 2025 contributions.